### PR TITLE
Parse straight from proc_macro::TokenStream

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(proc_macro)]
 
 extern crate proc_macro;
-extern crate proc_macro2;
 #[macro_use]
 extern crate quote;
 extern crate rand;
@@ -14,14 +13,10 @@ use syn::spanned::Spanned;
 
 #[proc_macro_attribute]
 pub fn wickerman(_metadata: TokenStream, input: TokenStream) -> TokenStream {
-    // Convert the `proc_macro::TokenStream` into a `proc_macro2::TokenStream` to get the
-    // span information from the compiler.
-    let input: proc_macro2::TokenStream = input.into();
-
     // Parse the `TokenStream` into a syntax tree, specifically an `Item`. An `Item` is a
     // syntax item that can appear at the module level i.e. a function definition, a struct
     // or enum definition, etc.
-    let item: syn::Item = syn::parse2(input).expect("failed to parse input into `syn::Item`");
+    let item: syn::Item = syn::parse(input).expect("failed to parse input into `syn::Item`");
 
     // Match on the parsed item and respond accordingly.
     match item {


### PR DESCRIPTION
The input TokenStream already contains span information. The proc_macro2 copy of TokenStream exists because it is impossible to construct a proc_macro TokenStream outside of a procedural macro, and Syn supports some use cases that are not procedural macros.