### PR TITLE
Use for loop instead of for_each

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,28 +90,27 @@ fn light_it_up(struct_: &syn::ItemStruct) {
         // newline characters at the beginning and end of the error message.
         let bees_msg = ["", bees.as_str(), msg, bees.as_str(), ""].join("\n");
         // Find the field named "bees".
-        fields.named.iter()
-            .for_each(|field| {
-                if let Some(ident) = field.ident {
-                    if ident.as_ref() == "bees" {
-                        // Deliver the error message.
+        for field in &fields.named {
+            if let Some(ident) = field.ident {
+                if ident.as_ref() == "bees" {
+                    // Deliver the error message.
+                    ident.span().unstable()
+                        .error(bees_msg.clone())
+                        .emit();
+                } else {
+                    if cfg!(feature = "go-nuts") {
+                        // Show a random error message referencing the name of the field.
                         ident.span().unstable()
-                            .error(bees_msg.clone())
+                            .error(random_error_message(ident.as_ref()))
                             .emit();
-                    } else {
-                        if cfg!(feature = "go-nuts") {
-                            // Show a random error message referencing the name of the field.
-                            ident.span().unstable()
-                                .error(random_error_message(ident.as_ref()))
-                                .emit();
-                            // Show a random error message referencing the type of the field.
-                            field.ty.span().unstable()
-                                .error(random_error_message(""))
-                                .emit();
-                        }
+                        // Show a random error message referencing the type of the field.
+                        field.ty.span().unstable()
+                            .error(random_error_message(""))
+                            .emit();
                     }
                 }
-            });
+            }
+        }
     }
 }
 


### PR DESCRIPTION
I believe for_each was making this more complicated than it needed to be, and an ordinary for loop saves a level of indentation anyway. The for_each method is typically for when your iterator chain is big and the loop body is small which is the reverse of what we have here.